### PR TITLE
Update to marine-sweep-width-data 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@canterbury-air-patrol/marine-sweep-width-data": "^0.1.0",
+        "@canterbury-air-patrol/marine-sweep-width-data": "^0.2.0",
         "bootstrap": "^5.3.3",
         "esbuild": "^0.24.0",
         "eslint": "^9.17.0",
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@canterbury-air-patrol/marine-sweep-width-data": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-sweep-width-data/-/marine-sweep-width-data-0.1.0.tgz",
-      "integrity": "sha512-b7vlJIx98EGugQhm57ril1yQmKbLzbFwTYKvae0BZrBhdSMI4OPEkxsd2mqvF7z89ItfMWN5ZdHg0Dhf5UE3HQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-sweep-width-data/-/marine-sweep-width-data-0.2.0.tgz",
+      "integrity": "sha512-lZf4kPBlUzZPh5rY9DtnvpQ0vwpj6ExGzm/PeYfabzdKPw4UEg/r32DulPQSRgk9PHsPSQkNRzFmhZQxZVntWw==",
       "license": "PDDL-1.0"
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/canterbury-air-patrol/marine-sar-search-prep#readme",
   "dependencies": {
-    "@canterbury-air-patrol/marine-sweep-width-data": "^0.1.0",
+    "@canterbury-air-patrol/marine-sweep-width-data": "^0.2.0",
     "bootstrap": "^5.3.3",
     "esbuild": "^0.24.0",
     "eslint": "^9.17.0",


### PR DESCRIPTION
## Description

0.2.0 brings in support for typescript

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Build:
- Update the dependency '@canterbury-air-patrol/marine-sweep-width-data' to version 0.2.0 in package.json.